### PR TITLE
Fix frontend public network access drift

### DIFF
--- a/infra/modules/frontend.bicep
+++ b/infra/modules/frontend.bicep
@@ -20,6 +20,7 @@ resource app 'Microsoft.Web/sites@2023-12-01' = {
   kind: 'app,linux'
   properties: {
     serverFarmId: plan.id
+    publicNetworkAccess: 'Enabled'
     siteConfig: {
       linuxFxVersion: 'NODE|20-lts'
       healthCheckPath: '/health'


### PR DESCRIPTION
## Summary
- explicitly enable public network access for the frontend App Service in Bicep
- preserve the intended public reachability of the customer-facing trading app across redeployments
- align infrastructure with the live outage fix

## Validation
- frontend root returned 200 after restoring public access
- frontend /orders returned 200
- frontend /payments returned 200
- gateway /health returned 200
- gateway /api/orders returned 200
- gateway /api/payments returned 200

---
Created by [Azure SRE Agent](https://sre.azure.com/agents/subscriptions/cbf44432-7f45-4906-a85d-d2b14a1e8328/resourceGroups/rg-contoso-agent-v3/providers/Microsoft.App/agents/contoso-trading-agent-v3/views/thread/c9af28ae-46a0-41d8-be58-8a5320b6ea1a)