### PR TITLE
Add optional Dynatrace OneAgent support

### DIFF
--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -6,9 +6,29 @@ param environmentName string
 @description('Primary location')
 param location string = 'eastus2'
 
+@description('Enable Dynatrace OneAgent auto-instrumentation on Container Apps')
+param enableDynatrace bool = false
+
+@description('Dynatrace environment URL (e.g. https://abc12345.live.dynatrace.com)')
+param dtEnvironmentUrl string = ''
+
+@description('Dynatrace API token (for OneAgent communication)')
+@secure()
+param dtApiToken string = ''
+
 var tags = { 'azd-env-name': environmentName }
 var rgName = 'rg-${environmentName}'
 var suffix = uniqueString(subscription().subscriptionId, rgName)
+
+// Dynatrace env vars — injected into every Container App when enabled
+var dtEnvVars = enableDynatrace ? [
+  { name: 'DT_TENANT', value: dtEnvironmentUrl }
+  { name: 'DT_TENANTTOKEN', secretRef: 'dt-api-token' }
+  { name: 'DT_CONNECTION_POINT', value: '${dtEnvironmentUrl}/communication' }
+] : []
+var dtSecrets = enableDynatrace ? [
+  { name: 'dt-api-token', value: dtApiToken }
+] : []
 
 resource rg 'Microsoft.Resources/resourceGroups@2021-04-01' = {
   name: rgName
@@ -98,6 +118,8 @@ module gateway 'modules/gateway.bicep' = {
     aiConnStr: monitoring.outputs.aiConnStr
     orderServiceUrl: orderService.outputs.url
     paymentServiceUrl: paymentService.outputs.url
+    dtEnvVars: dtEnvVars
+    dtSecrets: dtSecrets
   }
 }
 
@@ -117,6 +139,8 @@ module orderService 'modules/order-service.bicep' = {
     aiConnStr: monitoring.outputs.aiConnStr
     dbConnStr: database.outputs.connStr
     sbName: serviceBus.outputs.sbName
+    dtEnvVars: dtEnvVars
+    dtSecrets: dtSecrets
   }
 }
 
@@ -135,6 +159,8 @@ module paymentService 'modules/payment-service.bicep' = {
     acrPassword: registry.outputs.acrPassword
     aiConnStr: monitoring.outputs.aiConnStr
     dbConnStr: database.outputs.connStr
+    dtEnvVars: dtEnvVars
+    dtSecrets: dtSecrets
   }
 }
 
@@ -154,6 +180,8 @@ module worker 'modules/worker-service.bicep' = {
     aiConnStr: monitoring.outputs.aiConnStr
     dbConnStr: database.outputs.connStr
     sbName: serviceBus.outputs.sbName
+    dtEnvVars: dtEnvVars
+    dtSecrets: dtSecrets
   }
 }
 

--- a/infra/modules/gateway.bicep
+++ b/infra/modules/gateway.bicep
@@ -9,6 +9,8 @@ param acrPassword string
 param aiConnStr string
 param orderServiceUrl string
 param paymentServiceUrl string
+param dtEnvVars array = []
+param dtSecrets array = []
 
 resource app 'Microsoft.App/containerApps@2024-03-01' = {
   name: 'gateway-${suffix}'
@@ -18,9 +20,9 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     managedEnvironmentId: envId
     configuration: {
-      secrets: [
+      secrets: concat([
         { name: 'acr-password', value: acrPassword }
-      ]
+      ], dtSecrets)
       registries: [
         { server: acrServer, username: acrName, passwordSecretRef: 'acr-password' }
       ]
@@ -32,11 +34,11 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'gateway'
           image: 'mcr.microsoft.com/dotnet/samples:aspnetapp'
           resources: { cpu: json('0.5'), memory: '1Gi' }
-          env: [
+          env: concat([
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: aiConnStr }
             { name: 'ORDER_SERVICE_URL', value: orderServiceUrl }
             { name: 'PAYMENT_SERVICE_URL', value: paymentServiceUrl }
-          ]
+          ], dtEnvVars)
         }
       ]
       scale: { minReplicas: 1, maxReplicas: 3 }

--- a/infra/modules/order-service.bicep
+++ b/infra/modules/order-service.bicep
@@ -9,6 +9,8 @@ param acrPassword string
 param aiConnStr string
 param dbConnStr string
 param sbName string
+param dtEnvVars array = []
+param dtSecrets array = []
 
 resource app 'Microsoft.App/containerApps@2024-03-01' = {
   name: 'order-svc-${suffix}'
@@ -18,10 +20,10 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     managedEnvironmentId: envId
     configuration: {
-      secrets: [
+      secrets: concat([
         { name: 'acr-password', value: acrPassword }
         { name: 'db-conn', value: dbConnStr }
-      ]
+      ], dtSecrets)
       registries: [
         { server: acrServer, username: acrName, passwordSecretRef: 'acr-password' }
       ]
@@ -33,11 +35,11 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'order-service'
           image: 'mcr.microsoft.com/dotnet/samples:aspnetapp'
           resources: { cpu: json('0.5'), memory: '1Gi' }
-          env: [
+          env: concat([
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: aiConnStr }
             { name: 'DATABASE_URL', secretRef: 'db-conn' }
             { name: 'SERVICEBUS_NAMESPACE', value: sbName }
-          ]
+          ], dtEnvVars)
         }
       ]
       scale: { minReplicas: 1, maxReplicas: 5 }

--- a/infra/modules/payment-service.bicep
+++ b/infra/modules/payment-service.bicep
@@ -8,6 +8,8 @@ param acrName string
 param acrPassword string
 param aiConnStr string
 param dbConnStr string
+param dtEnvVars array = []
+param dtSecrets array = []
 
 resource app 'Microsoft.App/containerApps@2024-03-01' = {
   name: 'payment-svc-${suffix}'
@@ -17,10 +19,10 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     managedEnvironmentId: envId
     configuration: {
-      secrets: [
+      secrets: concat([
         { name: 'acr-password', value: acrPassword }
         { name: 'db-conn', value: dbConnStr }
-      ]
+      ], dtSecrets)
       registries: [
         { server: acrServer, username: acrName, passwordSecretRef: 'acr-password' }
       ]
@@ -32,10 +34,10 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'payment-service'
           image: 'mcr.microsoft.com/dotnet/samples:aspnetapp'
           resources: { cpu: json('0.5'), memory: '1Gi' }
-          env: [
+          env: concat([
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: aiConnStr }
             { name: 'DATABASE_URL', secretRef: 'db-conn' }
-          ]
+          ], dtEnvVars)
         }
       ]
       scale: { minReplicas: 1, maxReplicas: 3 }

--- a/infra/modules/worker-service.bicep
+++ b/infra/modules/worker-service.bicep
@@ -9,6 +9,8 @@ param acrPassword string
 param aiConnStr string
 param dbConnStr string
 param sbName string
+param dtEnvVars array = []
+param dtSecrets array = []
 
 resource app 'Microsoft.App/containerApps@2024-03-01' = {
   name: 'worker-${suffix}'
@@ -18,10 +20,10 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
   properties: {
     managedEnvironmentId: envId
     configuration: {
-      secrets: [
+      secrets: concat([
         { name: 'acr-password', value: acrPassword }
         { name: 'db-conn', value: dbConnStr }
-      ]
+      ], dtSecrets)
       registries: [
         { server: acrServer, username: acrName, passwordSecretRef: 'acr-password' }
       ]
@@ -32,12 +34,12 @@ resource app 'Microsoft.App/containerApps@2024-03-01' = {
           name: 'worker'
           image: 'mcr.microsoft.com/dotnet/samples:aspnetapp'
           resources: { cpu: json('0.25'), memory: '0.5Gi' }
-          env: [
+          env: concat([
             { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: aiConnStr }
             { name: 'DATABASE_URL', secretRef: 'db-conn' }
             { name: 'SERVICEBUS_NAMESPACE', value: sbName }
             { name: 'WORKER_MODE', value: 'true' }
-          ]
+          ], dtEnvVars)
         }
       ]
       scale: { minReplicas: 1, maxReplicas: 3 }


### PR DESCRIPTION
## Summary
- Adds `enableDynatrace` toggle to `infra/main.bicep`
- When enabled, injects `DT_TENANT`, `DT_TENANTTOKEN`, `DT_CONNECTION_POINT` env vars into all Container Apps
- Zero app code changes — Dynatrace OneAgent auto-instruments .NET
- Default: disabled (no behavior change)

## Usage
```bash
azd env set ENABLE_DYNATRACE true
azd env set DT_ENVIRONMENT_URL https://abc12345.live.dynatrace.com
azd env set DT_API_TOKEN dt0c01.xxxx
azd up
```

## Testing
Deploy with `enableDynatrace=false` → verify no change.
Deploy with `enableDynatrace=true` + valid Dynatrace env → verify DT_* env vars on containers.