### PR TITLE
Add OpenTelemetry OTLP export to Dynatrace

### DIFF
--- a/gateway/Gateway.csproj
+++ b/gateway/Gateway.csproj
@@ -6,5 +6,9 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
   </ItemGroup>
 </Project>

--- a/gateway/Program.cs
+++ b/gateway/Program.cs
@@ -1,5 +1,24 @@
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddApplicationInsightsTelemetry();
+// Dynatrace OTLP export (active when DT_OTLP_ENDPOINT is set)
+var dtEndpoint = Environment.GetEnvironmentVariable("DT_OTLP_ENDPOINT");
+var dtToken = Environment.GetEnvironmentVariable("DT_OTLP_TOKEN");
+if (!string.IsNullOrEmpty(dtEndpoint))
+{
+    builder.Services.AddOpenTelemetry()
+        .WithTracing(tracing => tracing
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddOtlpExporter(o =>
+            {
+                o.Endpoint = new Uri(dtEndpoint);
+                o.Headers = $"Authorization=Api-Token {dtToken}";
+                o.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+            }));
+}
+
 builder.Services.AddHttpClient();
 var app = builder.Build();
 

--- a/order-service/OrderService.csproj
+++ b/order-service/OrderService.csproj
@@ -7,5 +7,9 @@
     <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
   </ItemGroup>
 </Project>

--- a/order-service/Program.cs
+++ b/order-service/Program.cs
@@ -1,8 +1,27 @@
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 using Azure.Messaging.ServiceBus;
 using Npgsql;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddApplicationInsightsTelemetry();
+// Dynatrace OTLP export (active when DT_OTLP_ENDPOINT is set)
+var dtEndpoint = Environment.GetEnvironmentVariable("DT_OTLP_ENDPOINT");
+var dtToken = Environment.GetEnvironmentVariable("DT_OTLP_TOKEN");
+if (!string.IsNullOrEmpty(dtEndpoint))
+{
+    builder.Services.AddOpenTelemetry()
+        .WithTracing(tracing => tracing
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddOtlpExporter(o =>
+            {
+                o.Endpoint = new Uri(dtEndpoint);
+                o.Headers = $"Authorization=Api-Token {dtToken}";
+                o.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+            }));
+}
+
 var app = builder.Build();
 
 var dbConn = Environment.GetEnvironmentVariable("DATABASE_URL") ?? "";

--- a/payment-service/PaymentService.csproj
+++ b/payment-service/PaymentService.csproj
@@ -6,5 +6,9 @@
   <ItemGroup>
     <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
   </ItemGroup>
 </Project>

--- a/payment-service/Program.cs
+++ b/payment-service/Program.cs
@@ -1,7 +1,26 @@
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 using Npgsql;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddApplicationInsightsTelemetry();
+// Dynatrace OTLP export (active when DT_OTLP_ENDPOINT is set)
+var dtEndpoint = Environment.GetEnvironmentVariable("DT_OTLP_ENDPOINT");
+var dtToken = Environment.GetEnvironmentVariable("DT_OTLP_TOKEN");
+if (!string.IsNullOrEmpty(dtEndpoint))
+{
+    builder.Services.AddOpenTelemetry()
+        .WithTracing(tracing => tracing
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddOtlpExporter(o =>
+            {
+                o.Endpoint = new Uri(dtEndpoint);
+                o.Headers = $"Authorization=Api-Token {dtToken}";
+                o.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+            }));
+}
+
 var app = builder.Build();
 
 var dbConn = Environment.GetEnvironmentVariable("DATABASE_URL") ?? "";

--- a/worker/Program.cs
+++ b/worker/Program.cs
@@ -1,7 +1,26 @@
+using OpenTelemetry;
+using OpenTelemetry.Trace;
 using Azure.Messaging.ServiceBus;
 
 var builder = WebApplication.CreateBuilder(args);
 builder.Services.AddApplicationInsightsTelemetry();
+// Dynatrace OTLP export (active when DT_OTLP_ENDPOINT is set)
+var dtEndpoint = Environment.GetEnvironmentVariable("DT_OTLP_ENDPOINT");
+var dtToken = Environment.GetEnvironmentVariable("DT_OTLP_TOKEN");
+if (!string.IsNullOrEmpty(dtEndpoint))
+{
+    builder.Services.AddOpenTelemetry()
+        .WithTracing(tracing => tracing
+            .AddAspNetCoreInstrumentation()
+            .AddHttpClientInstrumentation()
+            .AddOtlpExporter(o =>
+            {
+                o.Endpoint = new Uri(dtEndpoint);
+                o.Headers = $"Authorization=Api-Token {dtToken}";
+                o.Protocol = OpenTelemetry.Exporter.OtlpExportProtocol.HttpProtobuf;
+            }));
+}
+
 var app = builder.Build();
 
 var sbConn = Environment.GetEnvironmentVariable("SERVICEBUS_CONNECTION") ?? "";

--- a/worker/Worker.csproj
+++ b/worker/Worker.csproj
@@ -7,5 +7,9 @@
     <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="Azure.Messaging.ServiceBus" Version="7.17.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.22.0" />
+      <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.10.0" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.10.1" />
+    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
+    <PackageReference Include="OpenTelemetry.Exporter.OpenTelemetryProtocol" Version="1.10.0" />
   </ItemGroup>
 </Project>


### PR DESCRIPTION
## Summary
Adds OpenTelemetry OTLP trace export to all 4 .NET services. When `DT_OTLP_ENDPOINT` is set, traces are sent to Dynatrace. When not set, no change to existing behavior.

## Env vars needed on Container Apps
- `DT_OTLP_ENDPOINT` — e.g. `https://dhu66396.live.dynatrace.com/api/v2/otlp/v1/traces`
- `DT_OTLP_TOKEN` — Dynatrace API token with `openTelemetryTrace.ingest` scope

## Testing
1. Deploy without DT env vars → App Insights only (no regression)
2. Deploy with DT env vars → traces appear in Dynatrace Distributed Traces